### PR TITLE
Swap project order

### DIFF
--- a/index.css
+++ b/index.css
@@ -399,6 +399,10 @@ a:focus {
   text-decoration: underline;
 }
 
+abbr {
+  cursor: help;
+}
+
 svg {
   fill: currentColor;
 }
@@ -513,6 +517,20 @@ a:hover .callout__text {
 
 .project__icon {
   margin-right: 2ch;
+}
+
+.project__icon--wip {
+  position: relative;
+  top: -2em;
+  transform: rotate(-20deg);
+  display: flex;
+  flex-flow: column nowrap;
+}
+
+.project__icon--wip svg {
+  width: 2em;
+  height: 2em;
+  margin-left: 2ch;
 }
 
 .project__item-site {

--- a/index.html
+++ b/index.html
@@ -39,25 +39,6 @@
       <!-- end site header -->
 
       <!-- project 1 -->
-      <div class="project__header project__header--bill">
-        <svg class="icon project__icon"><use xlink:href="#icon--bill" /></svg>
-        <h2 class="project__title">NYS Bill Tracker for Police Reform</h2>
-      </div>
-
-      <p class="project__item project__description">Easily track the progress of NY State legistation package for police reform.</p>
-
-      <a class="project__item project__item-site callout" href="https://astoria-tech-bill-tracker-master.dev.shipyard.host/">
-        <svg class="icon callout__icon"><use xlink:href="#icon--link" /></svg>
-        <span class="callout__text">Live Site</span>
-      </a>
-
-      <a class="project__item project__item-code callout" href="https://github.com/astoria-tech/bill-tracker">
-        <svg class="icon callout__icon"><use xlink:href="#icon--filecode" /></svg>
-        <span class="callout__text">View Code</span>
-      </a>
-      <!-- end project 1 -->
-
-      <!-- project 2 -->
       <div class="project__header project__header--dispatch">
         <svg class="icon project__icon"><use xlink:href="#icon--ama" /></svg>
         <h2 class="project__title">Mutual Aid Volunteer Dispatch</h2>
@@ -71,6 +52,25 @@
       </a>
 
       <a class="project__item project__item-code callout" href="https://github.com/astoria-tech/volunteer-dispatch">
+        <svg class="icon callout__icon"><use xlink:href="#icon--filecode" /></svg>
+        <span class="callout__text">View Code</span>
+      </a>
+      <!-- end project 1 -->
+
+      <!-- project 2 -->
+      <div class="project__header project__header--bill">
+        <svg class="icon project__icon"><use xlink:href="#icon--bill" /></svg>
+        <h2 class="project__title">NYS Bill Tracker for Police Reform</h2>
+      </div>
+
+      <p class="project__item project__description">Easily track the progress of NY State legistation package for police reform.</p>
+
+      <a class="project__item project__item-site callout" href="https://astoria-tech-bill-tracker-master.dev.shipyard.host/">
+        <svg class="icon callout__icon"><use xlink:href="#icon--link" /></svg>
+        <span class="callout__text">Live Site</span>
+      </a>
+
+      <a class="project__item project__item-code callout" href="https://github.com/astoria-tech/bill-tracker">
         <svg class="icon callout__icon"><use xlink:href="#icon--filecode" /></svg>
         <span class="callout__text">View Code</span>
       </a>

--- a/index.html
+++ b/index.html
@@ -59,6 +59,10 @@
 
       <!-- project 2 -->
       <div class="project__header project__header--bill">
+        <div class="project__icon--wip">
+          <svg class="icon project__icon"><use xlink:href="#icon--wip" /></svg>
+          <abbr title="Work in progress">WIP</abbr>
+        </div>
         <svg class="icon project__icon"><use xlink:href="#icon--bill" /></svg>
         <h2 class="project__title">NYS Bill Tracker for Police Reform</h2>
       </div>
@@ -78,6 +82,10 @@
 
       <!-- project 3 -->
       <div class="project__header project__header--last project__header--police">
+        <div class="project__icon--wip">
+          <svg class="icon project__icon"><use xlink:href="#icon--wip" /></svg>
+          <abbr title="Work in progress">WIP</abbr>
+        </div>
         <svg class="icon project__icon"><use xlink:href="#icon--policehat" /></svg>
         <h2 class="project__title">NYPD Disciplinary Records</h2>
       </div>


### PR DESCRIPTION
Put projects in completed-ness order.

Add first pass of implementation for WIP icon. Screenshots of the design.

![Screen Shot 2020-07-31 at 15 55 24-fullpage](https://user-images.githubusercontent.com/637174/89072525-bec56380-d346-11ea-97f3-96a322857fe8.png)
![Screen Shot 2020-07-31 at 15 55 38-fullpage](https://user-images.githubusercontent.com/637174/89072529-c08f2700-d346-11ea-944e-1c558c30ed29.png)
