### PR TITLE
Replace police records site with FOIL requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,26 @@
       <!-- end project 1 -->
 
       <!-- project 2 -->
-      <div class="project__header project__header--bill">
+      <div class="project__header project__header--foil">
+        <svg class="icon project__icon"><use xlink:href="#icon--policehat" /></svg>
+        <h2 class="project__title">How to file a FOIL request</h2>
+      </div>
+
+      <p class="project__item project__description">A line-by-line breakdown on how to file a Freedom of Information request in New York state.</p>
+
+      <a class="project__item project__item-site callout" href="https://foil.astoria.digital">
+        <svg class="icon callout__icon"><use xlink:href="#icon--link" /></svg>
+        <span class="callout__text">Live Site</span>
+      </a>
+
+      <a class="project__item project__item-code callout" href="https://github.com/astoria-tech/FOIL-Request">
+        <svg class="icon callout__icon"><use xlink:href="#icon--filecode" /></svg>
+        <span class="callout__text">View Code</span>
+      </a>
+      <!-- end project 2-->
+
+      <!-- project 3 -->
+      <div class="project__header project__header--last project__header--bill">
         <div class="project__icon--wip">
           <svg class="icon project__icon"><use xlink:href="#icon--wip" /></svg>
           <abbr title="Work in progress">WIP</abbr>
@@ -78,30 +97,7 @@
         <svg class="icon callout__icon"><use xlink:href="#icon--filecode" /></svg>
         <span class="callout__text">View Code</span>
       </a>
-      <!-- end project 2 -->
-
-      <!-- project 3 -->
-      <div class="project__header project__header--last project__header--police">
-        <div class="project__icon--wip">
-          <svg class="icon project__icon"><use xlink:href="#icon--wip" /></svg>
-          <abbr title="Work in progress">WIP</abbr>
-        </div>
-        <svg class="icon project__icon"><use xlink:href="#icon--policehat" /></svg>
-        <h2 class="project__title">NYPD Disciplinary Records</h2>
-      </div>
-
-      <p class="project__item project__description">Look up disclosed disciplinary records of NYPD officers.</p>
-
-      <a class="project__item project__item-site callout" href="https://astoria-tech-police-discipline-master.dev.shipyard.host/">
-        <svg class="icon callout__icon"><use xlink:href="#icon--link" /></svg>
-        <span class="callout__text">Live Site</span>
-      </a>
-
-      <a class="project__item project__item-code callout" href="https://github.com/astoria-tech/police-discipline">
-        <svg class="icon callout__icon"><use xlink:href="#icon--filecode" /></svg>
-        <span class="callout__text">View Code</span>
-      </a>
-      <!-- end project 3-->
+      <!-- end project 3 -->
 
       <div class="project__header project__header--more">
         <p>More projects coming…</p>


### PR DESCRIPTION
Since the police records project repo has essentially been supplanted by
the Muckrock work for now, replace that item on our site with a link to
the live and non-WIP FOIL request site.