### PR TITLE
Reverse link color

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
             <svg class="project__icon"><use xlink:href="#icon--bill" /></svg>
             <h2 class="project__title">NYS Bill Tracker for Police Reform</h2>
           </div>
-          <p class="project__description"><span class="project__wip">Work in progress</span><br>This a project that keeps track of bills specific to police reform. <br>The project is in progress, it uses a table layout to show the path of each bill and which is close to being passed and which need more support.</p>
+          <p class="project__description">This a project that keeps track of bills specific to police reform. <br>The project is in progress, it uses a table layout to show the path of each bill and which is close to being passed and which need more support.</p>
           <div class="project__links">
             <a class="project__link" href="https://bills.astoria.digital/">
               <svg class="project__link-icon"><use xlink:href="#icon--wiplink" /></svg>

--- a/styles.css
+++ b/styles.css
@@ -519,11 +519,6 @@ svg {
   height: 6em;
 }
 
-.project__link {
-  display: flex;
-  flex-flow: row wrap;
-}
-
 .project__header {
   display: flex;
   flex-flow: row nowrap;
@@ -546,14 +541,15 @@ svg {
   flex-flow: row wrap;
   align-items: center;
   width: max-content;
+  background-color: var(--highlight-yellow);
+}
+
+.project__link:hover {
+  background-color: transparent;
 }
 
 .project__link + .project__link {
   margin-top: 1em;
-}
-
-.project__link:hover {
-  background-color: var(--highlight-yellow);
 }
 
 .project__link-icon {


### PR DESCRIPTION
Make the project link color highlight yellow by default, then change to
transparent on hover, as discussed in our last meeting.

Also, remove the Work in progress indicator from the bill tracker
project, also as discussed.