### PR TITLE
Add three column layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,175 +44,170 @@
         <a href="/" class="site-header__text">astoria.digital</a>
       </h1>
       <p class="site-header__slogan">digital volunteers<br /> for the community</p>
-      
+
       <!-- <a href="mailto:team@astoria.digital?subject=feedback" class="site-header__contact">
         <svg class="project__icon"><use xlink:href="#icon--email" /></svg>
         <span class="project__text">Contact Us</span> -->
 
-      
+
       </a>
     </header>
 
     <main>
-      <section>
-        <div class="projects-content">
-          <h1>Projects</h1>
+      <section class="projects-content">
+        <h1>Projects</h1>
 
-          <div class="projects">
+        <div class="projects">
 
-            <div class="project">
-              <div class="project__header project__header--dispatch">
-                <svg class="project__icon"><use xlink:href="#icon--ama" /></svg>
-                <h2 class="project__title">Volunteer Dispatch Bot</h2>
-              </div>
-              <p class="project__description">The system that Astoria Mutual Aid Network uses to connect requests for help from neighbors with the network’s volunteers. Astoria Mutual Aid Network came about at the beginning of the pandemic, and our team was created to support their work.</p>
-              <div class="project__links">
-                <a class="project__link" href="https://astoriamutualaid.com/">
-                  <span class="project__text">Astoria Mutual Aid Network Website</span>
-                </a>
-                <a class="project__link" href="https://github.com/astoria-tech/volunteer-dispatch">
-                  <span class="project__text">View Code</span>
-                </a>
-              </div>
+          <div class="project">
+            <div class="project__header project__header--dispatch">
+              <svg class="project__icon"><use xlink:href="#icon--ama" /></svg>
+              <h2 class="project__title">Volunteer Dispatch Bot</h2>
             </div>
-
-            <div class="project">
-              <div class="project__header project__header--board">
-                <svg class="project__icon"><use xlink:href="#icon--board" /></svg>
-                <h2 class="project__title">Astoria Community Bulletin Board</h2>
-              </div>
-              <p class="project__description">Lists volunteer oppourtunities with local community groups and has a submission form to add new volunteer roles</p>
-              <div class="project__links">
-                <a class="project__link" href="https://board.astoria.digital/">
-                  <span class="project__text">Live Site</span>
-                </a>
-                <a class="project__link" href="https://github.com/astoria-tech/Community-Bulletin-Board">
-                  <span class="project__text">View Code</span>
-                </a>
-              </div>
+            <p class="project__description">The system that Astoria Mutual Aid Network uses to connect requests for help from neighbors with the network’s volunteers. Astoria Mutual Aid Network came about at the beginning of the pandemic, and our team was created to support their work.</p>
+            <div class="project__links">
+              <a class="project__link" href="https://astoriamutualaid.com/">
+                <span class="project__text">Astoria Mutual Aid Network Website</span>
+              </a>
+              <a class="project__link" href="https://github.com/astoria-tech/volunteer-dispatch">
+                <span class="project__text">View Code</span>
+              </a>
             </div>
+          </div>
 
-            <div class="project">
-              <div class="project__header project__header--foil">
-                <svg class="project__icon"><use xlink:href="#icon--courthouse" /></svg>
-                <h2 class="project__title">How to file a FOIL request in New York State</h2>
-              </div>
-              <p class="project__description">A line-by-line breakdown on how to file a Freedom of Information request in New York state.</p>
-              <div class="project__links">
-                <a class="project__link" href="https://foil.astoria.digital">
-                  <span class="project__text">Live Site</span>
-                </a>
-                <a class="project__link" href="https://github.com/astoria-tech/FOIL-Request">
-                  <span class="project__text">View Code</span>
-                </a>
-              </div>
+          <div class="project">
+            <div class="project__header project__header--board">
+              <svg class="project__icon"><use xlink:href="#icon--board" /></svg>
+              <h2 class="project__title">Astoria Community Bulletin Board</h2>
             </div>
-
-            <div class="project">
-              <div class="project__header project__header--bill">
-                <svg class="project__icon"><use xlink:href="#icon--bill" /></svg>
-                <h2 class="project__title">New York State Bill Tracker</h2>
-              </div>
-              <p class="project__description">An overview of progress on New York State Senate bills that have been introduced.</p>
-              <div class="project__links">
-                <a class="project__link" href="https://bills.astoria.digital/">
-                  <span class="project__text">Live Site</span>
-                </a>
-                <a class="project__link" href="https://github.com/astoria-tech/bill-tracker">
-                  <span class="project__text">View Code</span>
-                </a>
-              </div>
+            <p class="project__description">Lists volunteer oppourtunities with local community groups and has a submission form to add new volunteer roles</p>
+            <div class="project__links">
+              <a class="project__link" href="https://board.astoria.digital/">
+                <span class="project__text">Live Site</span>
+              </a>
+              <a class="project__link" href="https://github.com/astoria-tech/Community-Bulletin-Board">
+                <span class="project__text">View Code</span>
+              </a>
             </div>
+          </div>
 
-            <div class="project">
-              <div class="project__header project__header--covid-wait-times">
-                <svg class="project__icon"><use xlink:href="#icon--clock" /></svg>
-                <h2 class="project__title">NYC COVID 19 Testing Wait Times</h2>
-              </div>
-              <p class="project__description">Data and analysis on COVID-19 testing wait times around New York City.</p>
-              <div class="project__links">
-                <a class="project__link" href="https://datastudio.google.com/u/0/reporting/1506fb15-ab88-4226-a251-59a114affd9c/page/EdRsB">
-                  <span class="project__text">Live Site</span>
-                </a>
-                <a class="project__link" href="https://github.com/astoria-tech/nyc-covid19-testing-wait-times">
-                  <span class="project__text">View Code</span>
-                </a>
-              </div>
+          <div class="project">
+            <div class="project__header project__header--foil">
+              <svg class="project__icon"><use xlink:href="#icon--courthouse" /></svg>
+              <h2 class="project__title">How to file a FOIL request in New York State</h2>
             </div>
+            <p class="project__description">A line-by-line breakdown on how to file a Freedom of Information request in New York state.</p>
+            <div class="project__links">
+              <a class="project__link" href="https://foil.astoria.digital">
+                <span class="project__text">Live Site</span>
+              </a>
+              <a class="project__link" href="https://github.com/astoria-tech/FOIL-Request">
+                <span class="project__text">View Code</span>
+              </a>
+            </div>
+          </div>
 
-          </div><!-- end projects -->
+          <div class="project">
+            <div class="project__header project__header--bill">
+              <svg class="project__icon"><use xlink:href="#icon--bill" /></svg>
+              <h2 class="project__title">New York State Bill Tracker</h2>
+            </div>
+            <p class="project__description">An overview of progress on New York State Senate bills that have been introduced.</p>
+            <div class="project__links">
+              <a class="project__link" href="https://bills.astoria.digital/">
+                <span class="project__text">Live Site</span>
+              </a>
+              <a class="project__link" href="https://github.com/astoria-tech/bill-tracker">
+                <span class="project__text">View Code</span>
+              </a>
+            </div>
+          </div>
 
-        </div><!-- end projects-content -->
-      </section>
+          <div class="project">
+            <div class="project__header project__header--covid-wait-times">
+              <svg class="project__icon"><use xlink:href="#icon--clock" /></svg>
+              <h2 class="project__title">NYC COVID 19 Testing Wait Times</h2>
+            </div>
+            <p class="project__description">Data and analysis on COVID-19 testing wait times around New York City.</p>
+            <div class="project__links">
+              <a class="project__link" href="https://datastudio.google.com/u/0/reporting/1506fb15-ab88-4226-a251-59a114affd9c/page/EdRsB">
+                <span class="project__text">Live Site</span>
+              </a>
+              <a class="project__link" href="https://github.com/astoria-tech/nyc-covid19-testing-wait-times">
+                <span class="project__text">View Code</span>
+              </a>
+            </div>
+          </div>
 
-      <section>
-        <div class="aboutus-content">
-          <h1>About Us</h1>
+        </div><!-- end projects -->
+      </section><!-- end projects-content -->
 
-          <div class="aboutus-columns">
-            <div class="aboutus-column-left">
-              <div class="our-story">
-                <h2>Our story</h2>
-                <p>We are a group of volunteer designers and software engineers from Astoria, Queens. Our mission is to support the work of volunteer groups in our neighborhood with digital tools and create interfaces for civic engagement.</p>
-                <p>Astoria Digital started at the beginning of the covid 19 pandemic in Astoria, Queens. Peter Valdez organized the Astoria Tech meetup that connected software engineers in the neighborhood. When he saw a flier in the neighborhood for Astoria Mutual Aid Network, he reached out to the founder and helped them create a dispatch bot that connected the airtable base with the slack to connect requests from neighbors with volunteers.</p>
-                <p>Since then, we have expanded our projects by collaborating withcreating a guide to completing a FOIL request in New York state. We have continued collaborating with grassroots groups in Astoria by creating the Community Bulletin Board. Our goal is to share the tools we make with other neighborhoods.</p>
-              </div><!-- end .our-story -->
+      <section class="aboutus-content">
+        <h1>About Us</h1>
 
-              <div class="contact-us">
-                <h2>Contact Us</h2>
+        <div class="aboutus-columns">
+          <div class="aboutus-column-left">
+            <div class="our-story">
+              <h2>Our story</h2>
+              <p>We are a group of volunteer designers and software engineers from Astoria, Queens. Our mission is to support the work of volunteer groups in our neighborhood with digital tools and create interfaces for civic engagement.</p>
+              <p>Astoria Digital started at the beginning of the covid 19 pandemic in Astoria, Queens. Peter Valdez organized the Astoria Tech meetup that connected software engineers in the neighborhood. When he saw a flier in the neighborhood for Astoria Mutual Aid Network, he reached out to the founder and helped them create a dispatch bot that connected the airtable base with the slack to connect requests from neighbors with volunteers.</p>
+              <p>Since then, we have expanded our projects by collaborating withcreating a guide to completing a FOIL request in New York state. We have continued collaborating with grassroots groups in Astoria by creating the Community Bulletin Board. Our goal is to share the tools we make with other neighborhoods.</p>
+            </div><!-- end .our-story -->
 
-                <p>Reach out to us by <a href="mailto:team@astoria.digital">email</a> and follow us on <a href="https://twitter.com/AstoriaDigital" target= _blank>twitter</a> and <a href="https://www.instagram.com/astoria.digital/" target= _blank>instagram</a>.</p>
-                <p>If you are a community group interested in using our tools, we're excited to help!</p>
-              </div><!-- /.contact-us -->
-              
-            </div><!-- /.aboutus-column-left -->
+            <div class="contact-us">
+              <h2>Contact Us</h2>
 
-            <div class="aboutus-column-right">
-              <h2 class="team__title">Our team</h2>
+              <p>Reach out to us by <a href="mailto:team@astoria.digital">email</a> and follow us on <a href="https://twitter.com/AstoriaDigital" target= _blank>twitter</a> and <a href="https://www.instagram.com/astoria.digital/" target= _blank>instagram</a>.</p>
+              <p>If you are a community group interested in using our tools, we're excited to help!</p>
+            </div><!-- /.contact-us -->
 
-              <div class="team">
-                <div class="team__member">
-                  <svg class="team__icon"><use xlink:href="#icon--avatar-alex" /></svg>
-                  <p class="team__member-name">Alex</p>
-                </div>
-                <div class="team__member">
-                  <svg class="team__icon"><use xlink:href="#icon--avatar-ania" /></svg>
-                  <p class="team__member-name">Ania</p>
-                </div>
-                <div class="team__member">
-                  <svg class="team__icon"><use xlink:href="#icon--avatar-ash" /></svg>
-                  <p class="team__member-name">Ash</p>
-                </div>
-                <div class="team__member">
-                  <svg class="team__icon"><use xlink:href="#icon--avatar-chris" /></svg>
-                  <p class="team__member-name">Chris</p>
-                </div>
-                <div class="team__member">
-                  <svg class="team__icon"><use xlink:href="#icon--avatar-estafania" /></svg>
-                  <p class="team__member-name">Estefanía</p>
-                </div>
-                <div class="team__member">
-                  <svg class="team__icon"><use xlink:href="#icon--avatar-kyle" /></svg>
-                  <p class="team__member-name">Kyle</p>
-                </div>
-                <div class="team__member">
-                  <svg class="team__icon"><use xlink:href="#icon--avatar-omar" /></svg>
-                  <p class="team__member-name">Omar</p>
-                </div>
-                <div class="team__member">
-                  <svg class="team__icon"><use xlink:href="#icon--avatar-peter" /></svg>
-                  <p class="team__member-name">Peter</p>
-                </div>
-                <div class="team__member">
-                  <svg class="team__icon"><use xlink:href="#icon--avatar-vivek" /></svg>
-                  <p class="team__member-name">Vivek</p>
-                </div>
+          </div><!-- /.aboutus-column-left -->
 
-              </div><!-- /.team -->
-            </div><!-- /.aboutus-column-right -->
-          </div><!-- /.aboutus-columns -->
-        </div><!-- /.aboutus-content -->
-      </section>
+          <div class="aboutus-column-right">
+            <h2 class="team__title">Our team</h2>
+
+            <div class="team">
+              <div class="team__member">
+                <svg class="team__icon"><use xlink:href="#icon--avatar-alex" /></svg>
+                <p class="team__member-name">Alex</p>
+              </div>
+              <div class="team__member">
+                <svg class="team__icon"><use xlink:href="#icon--avatar-ania" /></svg>
+                <p class="team__member-name">Ania</p>
+              </div>
+              <div class="team__member">
+                <svg class="team__icon"><use xlink:href="#icon--avatar-ash" /></svg>
+                <p class="team__member-name">Ash</p>
+              </div>
+              <div class="team__member">
+                <svg class="team__icon"><use xlink:href="#icon--avatar-chris" /></svg>
+                <p class="team__member-name">Chris</p>
+              </div>
+              <div class="team__member">
+                <svg class="team__icon"><use xlink:href="#icon--avatar-estafania" /></svg>
+                <p class="team__member-name">Estefanía</p>
+              </div>
+              <div class="team__member">
+                <svg class="team__icon"><use xlink:href="#icon--avatar-kyle" /></svg>
+                <p class="team__member-name">Kyle</p>
+              </div>
+              <div class="team__member">
+                <svg class="team__icon"><use xlink:href="#icon--avatar-omar" /></svg>
+                <p class="team__member-name">Omar</p>
+              </div>
+              <div class="team__member">
+                <svg class="team__icon"><use xlink:href="#icon--avatar-peter" /></svg>
+                <p class="team__member-name">Peter</p>
+              </div>
+              <div class="team__member">
+                <svg class="team__icon"><use xlink:href="#icon--avatar-vivek" /></svg>
+                <p class="team__member-name">Vivek</p>
+              </div>
+
+            </div><!-- /.team -->
+          </div><!-- /.aboutus-column-right -->
+        </div><!-- /.aboutus-columns -->
+      </section><!-- /.aboutus-content -->
 
       <nav class="page-links">
         <a class="link-to-top" href="#top">back to top</a>

--- a/styles.css
+++ b/styles.css
@@ -569,6 +569,12 @@ section:first-child {
 
 @media screen and (min-width: 930px) {
   .project {
+    flex: 0 1 calc(50% - 1em);
+  }
+}
+
+@media screen and (min-width: 1361px) {
+  .project {
     flex: 0 1 438px;
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -563,6 +563,8 @@ section:first-child {
   border: 3px solid;
   margin-bottom: 2em;
   flex: 1 1 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 @media screen and (min-width: 930px) {

--- a/styles.css
+++ b/styles.css
@@ -371,6 +371,16 @@ body {
   }
 }
 
+main {
+  padding: 0 1em;
+}
+
+@media screen and (min-width: 1450px) {
+  main {
+    padding: 0;
+  }
+}
+
 h1, h2, h3, h4, h5, h6 {
   font-family: "Fjalla One", sans-serif;
   font-weight: normal;
@@ -457,16 +467,8 @@ section:first-child {
   margin: 0 auto;
 }
 
-.projects-content,
-.aboutus-content {
-  padding: 0 2em;
-}
-
-@media screen and (min-width: 1440px) {
-  .projects-content,
-  .aboutus-content {
-    padding: 0 5.5em;
-  }
+.site-header {
+  max-width: 2000px;
 }
 
 /* }}} */
@@ -515,7 +517,6 @@ section:first-child {
   margin: 0;
   font-size: 3rem;
   background-color: var(--highlight-yellow);
-  border-bottom: 3px solid;
 }
 
 .site-header__slogan {
@@ -538,13 +539,12 @@ section:first-child {
 
   .site-header__title {
     border-right: 3px solid;
-    border-bottom: none;
-    flex:2;
+    flex: 2;
   }
 
   .site-header__slogan {
     text-align: left;
-    flex:1;
+    flex: 1;
   }
 }
 
@@ -561,35 +561,14 @@ section:first-child {
 .project {
   width: 100%;
   border: 3px solid;
-  display: flex;
-  flex-direction: column;
   margin-bottom: 2em;
+  flex: 1 1 100%;
 }
 
-@media screen and (min-width: 870px) {
+@media screen and (min-width: 930px) {
   .project {
-    width: calc(50% - 1em);
+    flex: 0 1 438px;
   }
-}
-
-@media screen and (min-width: 1440px) {
-  .project {
-    width: calc(50% - 2.75em);
-    margin-bottom: 5.5em;
-  }
-}
-
-.project:first-child:nth-last-child(2),
-.project:first-child:nth-last-child(2) ~ .project,
-.project:first-child:nth-last-child(4),
-.project:first-child:nth-last-child(4) ~ .project,
-.project:first-child:nth-last-child(8),
-.project:first-child:nth-last-child(8) ~ .project,
-.project:first-child:nth-last-child(10),
-.project:first-child:nth-last-child(10) ~ .project,
-.project:first-child:nth-last-child(14),
-.project:first-child:nth-last-child(14) ~ .project {
-  flex: 1 1 450px;
 }
 
 .project__header,
@@ -692,7 +671,6 @@ section:first-child {
 
 /* }}} */
 
-
 /* Contact Us {{{ */
   
 /* }}} */
@@ -732,8 +710,6 @@ section:first-child {
 }
 
 /* }}} */
-
-
 
 /* Footer {{{ */
 
@@ -775,11 +751,6 @@ section:first-child {
     font-size: 2.5rem;
   }
 }
-
-/* }}} */
-
-/* Homepage specific {{{ */
-
 
 /* }}} */
 


### PR DESCRIPTION
Use `flex-basis` (via shorthand) that enables three column layout at
large widths, collapsing to two columns when there's less space, and a
single column when on mobile.

Remove the project padding from very large screens so the content will
go a little farther when we have the space.

Remove a layer of HTML nesting, and combine the inner `div` class with
the outer `section`. The styles remain the same here.

Remove the bottom border from the yellow background header on small
screens with the subtitle wraps below it to show the two are still
connected.

Remove some unused, legacy styles.