### PR TITLE
Card whitespace adjustments

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -560,7 +560,7 @@ section:first-child {
 
 .project {
   width: 100%;
-  border: 3px solid;
+  border: 2px solid;
   margin-bottom: 2em;
   flex: 1 1 100%;
   display: flex;
@@ -579,17 +579,14 @@ section:first-child {
   }
 }
 
-.project__header,
 .project__description,
 .project__links {
-  padding: 1em 2.5rem;
+  padding: 1em;
 }
 
 .project__header {
-  display: flex;
-  flex-flow: row nowrap;
-  justify-content: left;
-  border-bottom: 3px solid;
+  border-bottom: 2px solid;
+  padding: 1rem;
 }
 
 .project__title {
@@ -599,9 +596,10 @@ section:first-child {
 }
 
 .project__icon {
-  margin-right: 2ch;
-  width: 6em;
-  height: 6em;
+  float: left;
+  margin-right: 1ch;
+  width: 4em;
+  height: 4em;
 }
 
 .project__description {
@@ -610,7 +608,7 @@ section:first-child {
 }
 
 .project__links {
-  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22100%25%22%3E%3Cline%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20x1%3D%220%22%20x2%3D%22100%25%22%20y1%3D%221.5%22%20y2%3D%221.5%22%20stroke%3D%22%23000%22%20stroke-width%3D%223%22%20stroke-dasharray%3D%2210%2014%22%2F%3E%3C%2Fsvg%3E");
+  border-top: 2px dashed;
 }
 
 .project__link {
@@ -618,6 +616,10 @@ section:first-child {
   line-height: 1;
   font-size: 1.8rem;
   margin-bottom: 0.5em;
+}
+
+.project__link:last-of-type {
+  margin-bottom: 0;
 }
 
 @media screen and (min-width: 700px) {
@@ -652,10 +654,6 @@ section:first-child {
 .our-story,
 .contact-us {
   margin-bottom: 3em;
-}
-
-.our-story p {
-  margin: 0;
 }
 
 .aboutus-column-left {


### PR DESCRIPTION
Reduce border thickness and inner padding slightly to make the cards
feel less heavy.

Replace the SVG dashed line with the functional equivalent browser
default dashed border style. This saves some resources and lets us size
it differently (we reduce the thickness here to match new style).

Fix a double margin display bug what caused too much whitespace to
appear in the project links section.

Have the project header wrap around the icons, saving some space and
creating a pleasant effect.

Add back the paragraph spacing in our story section to keep consistent
and maintain readability.